### PR TITLE
Fix build issue. Support cargo build without --all-features

### DIFF
--- a/jirust-cli/Cargo.toml
+++ b/jirust-cli/Cargo.toml
@@ -22,7 +22,7 @@ toml = "0.9.2"
 clap = { version = "4.5", features = ["derive", "wrap_help"] }
 clap_derive = "4.5"
 rpassword = "7.4.0"
-jira_v3_openapi = { version = "1.3.7", default-features = false, features = [
+jira_v3_openapi = { path = "../jira_v3_openapi", features = [
     "common",
     "issues_api",
     "projects_api",


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?
Allow user just "cargo build" to build jirust-cli, don't need "cargo build --all-features"

Issue Number: #39 

## What is the new behavior?
Since jirust-cli and jira_v3_spec in same repo, directly use local path could use latest changes.


## Other information
I didn't upload Cargo.lock


# Checklist

- [ ] I have performed a self-review of my own code
- [ ] I have added tests to cover my changes
- [x] I have run succesfully
- [ ] I have run cargo deny check succesfully
- [ ] I have run cargo clippy succesfully (need only for jirust-cli crate)
